### PR TITLE
Instance name configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,16 @@
 			"language": "systemverilog",
 			"path": "./snippets/snippets.json"
 		}],
+		"configuration": {
+			"title": "",
+			"properties": {
+				"systemverilog.instancePrefix" :{
+					"type":"string",
+					"default": "u_",
+					"description": "The prefix to use when instantiating a new module"
+				}
+			}
+		},
 		"commands": [{
 			"command": "extension.systemverilog.instantiateModule",
 			"title": "System Verilog: Instantiate Module"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -226,22 +226,29 @@ function instantiateModule(srcpath: string) {
     if (portsName.length === 0) {
         return;
     }
-    let inst = moduleName + '\n';
+
+    let prefix =
+        vscode.workspace
+        .getConfiguration("systemverilog")['instancePrefix'];
+
+    let paramString = ``
     if (parametersName.length > 0) {
-        inst += '#(\n';
-        inst += instantiatePort(parametersName);
-        inst += ')\n';
+        paramString = `\n#(\n${instantiatePort(parametersName)})\n`
     }
-    inst += `u_${moduleName}(\n`;
-    inst += instantiatePort(portsName);
-    inst += ');\n';
-    return inst;
+
+    return new vscode.SnippetString()
+        .appendText(moduleName + " ")
+        .appendText(paramString)
+        .appendPlaceholder(prefix)
+        .appendPlaceholder(`${moduleName}(\n`)
+        .appendText(instantiatePort(portsName))
+        .appendText(');\n');
 }
 
 function instantiateModuleInteract() {
     let filePath = path.dirname(vscode.window.activeTextEditor.document.fileName);
     selectFile(filePath).then(srcpath => {
         let inst = instantiateModule(srcpath);
-        vscode.window.activeTextEditor.insertSnippet(new vscode.SnippetString(inst));
+        vscode.window.activeTextEditor.insertSnippet(inst);
     });
 }


### PR DESCRIPTION
Allow the default prefix for an instantiation to be configured in the settings for the extension.  This will also create a tab-able snippet to go through the name and other attributes of an instance. 
If there is a preferred method to accomplish the same goal I am open to it.