### PR TITLE
Adding support for .vs, .v, .vsh, .svh filetypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"languages": [{
 			"id": "systemverilog",
 			"aliases": ["System Verilog", "systemverilog"],
-			"extensions": [".sv",".SV"],
+			"extensions": [".sv",".SV",".vs",".VS",".v",".V",".vsh",".VSH",".svh",".SVH" ],
 			"configuration": "./language-configuration.json"
 		}],
 		"grammars": [{

--- a/syntaxes/systemverilog.tmLanguage
+++ b/syntaxes/systemverilog.tmLanguage
@@ -8,6 +8,14 @@ PUBLIC '-//Apple//DTD PLIST 1.0//EN'
     <array>
       <string>sv</string>
       <string>SV</string>
+      <string>svh</string>
+      <string>SVH</string>      
+      <string>v</string>
+      <string>V</string>
+      <string>vs</string>
+      <string>VS</string>    
+      <string>vsh</string>
+      <string>VSH</string>        
     </array>
     <key>foldingStartMarker</key>
     <string>(begin)\s*(//.*)?$</string>


### PR DESCRIPTION
Many companies uses different extensions for verilog/systemverilog files. 
As systemverilog covers verilog systax highlighting, this extension should support .v , .vs extensions