### PR TITLE
Fixed instantiate module command when imports are used before the module declaration.

### DIFF
--- a/src/instantiation.ts
+++ b/src/instantiation.ts
@@ -20,7 +20,9 @@ function instantiateModule(srcpath: string) {
       return;
   }
   // module 2001 style
-  let moduleIO = content.substring(content.indexOf('module'), content.indexOf(';'));
+  let moduleStart = content.indexOf('module');
+  let moduleEnd   = content.indexOf(';', moduleStart);
+  let moduleIO = content.substring(moduleStart, moduleEnd);
   let moduleName = moduleIO.match(/module\s+\b([A-Za-z_][A-Za-z0-9_]*)\b/)[1];
   let parametersName = [];
   let portsName = [];


### PR DESCRIPTION
If a package import is used before the module declaration, the existing code throws a null exception because of the ";" that appears at the end of the "import pkg::*;" line.

Instead, we need to look for the ";" that follows the "module" keyword to make sure we get the right module IO range.