### PR TITLE
Support hover and definition detection of rand variables

### DIFF
--- a/src/DefinitionProvider.ts
+++ b/src/DefinitionProvider.ts
@@ -32,7 +32,7 @@ export class SystemVerilogDefinitionProvider implements DefinitionProvider {
       return;
     }
 
-    let variableType = String.raw`\b(input|output|inout|reg|wire|logic|integer|bit|byte|shortint|int|longint|time|shortreal|real|double|realtime)\b\s+`;
+    let variableType = String.raw`\b(input|output|inout|reg|wire|logic|integer|bit|byte|shortint|int|longint|time|shortreal|real|double|realtime|rand|randc)\b\s+`;
     let variableTypeStart = '^' + variableType;
     let paraType = String.raw`^\b(parameter|localparam)\b\s+\b${target}\b`;
 

--- a/src/hover.ts
+++ b/src/hover.ts
@@ -34,7 +34,7 @@ export class SystemVerilogHoverProvider implements vscode.HoverProvider {
               return;
           }
   
-          let variableType = String.raw`\b(input|output|inout|reg|wire|logic|integer|bit|byte|shortint|int|longint|time|shortreal|real|double|realtime)\b\s+`;
+          let variableType = String.raw`\b(input|output|inout|reg|wire|logic|integer|bit|byte|shortint|int|longint|time|shortreal|real|double|realtime|rand|randc)\b\s+`;
           let variableTypeStart = '^' + variableType;
           let paraType = String.raw`^\b(parameter|localparam)\b\s+\b${target}\b`;
   
@@ -107,5 +107,3 @@ export class SystemVerilogHoverProvider implements vscode.HoverProvider {
       else
           return undefined;
   }
-  
-


### PR DESCRIPTION
Fixing issue #41 by adding `rand` and `randc` to the list of variable types.